### PR TITLE
Shrink and space nav links

### DIFF
--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -149,11 +149,12 @@ h1 {
 #nav .link {
     font-family: main;
     font-weight: 400;
-    font-size: 18pt;
     text-transform: uppercase;
     margin: auto 50px;
     text-decoration: none;
-    color: inherit
+	color: inherit;
+	font-size: 13pt;
+    letter-spacing: 0.2em;
 }
 
 #nav .link::after {


### PR DESCRIPTION
A small tweak to how the nav links look, if you perfer. Here's a screen cap of how the changes render:

**Before:**
![Screenshot of site as it is](https://user-images.githubusercontent.com/19389660/104142092-f28dc600-5387-11eb-91bb-522d3a05ee80.png)

**After:**
![Screenshot of site after changes have been applied, navigation links are slightly smaller and the letter spacing is more spaced-out](https://user-images.githubusercontent.com/19389660/104142083-ea358b00-5387-11eb-8ed0-e5d01ce3fe2c.png)
